### PR TITLE
Interop simplification and eror handling

### DIFF
--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -1,10 +1,9 @@
-﻿// See https://aka.ms/new-console-template for more information
-using kalkanNet;
+﻿using kalkanNet;
 
 var cert_path = "";
 var cert_pass = "";
 var xml = "<xml></xml>";
-var client = new KalkanClient(new Options(), new HttpClient());
+var client = new KalkanClient(new KalkanOptions());
         
 client.LoadKeyStore(cert_pass, cert_path, KCStoreType.KCStoreTypePKCS12, "");
 var signXml = client.SignXML(xml, "", "", "", "");

--- a/Sample/Properties/launchSettings.json
+++ b/Sample/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "Sample": {
+      "commandName": "Project"
+    },
+    "WSL": {
+      "commandName": "WSL",
+      "distributionName": "Ubuntu-22.04"
+    }
+  }
+}


### PR DESCRIPTION
- Do not perform manually loading of DLL, whole point of DllImport is you specify dynamic library (dll or so) and infrastructure do that loading for you.
- Do not hide errors. Throw exceptions if something is wrong. No need to guess where you do something wrong as end-user.
- Move library initialization to static constructor so it would be performed once, and synchronously by runtime. This allow have multipe classes of KalcanClient in different areas of applications.
- Rename Options to KalkanOptions, in your app you may have dozen of options in same configuraiton, so unlikely you will have name clash.
- Replace String with string because that's what most people use. Let me know if you insist on having it Java style.